### PR TITLE
Better way to check if a vm already exists

### DIFF
--- a/macos_okiomov.sh
+++ b/macos_okiomov.sh
@@ -97,7 +97,7 @@ fi
 
 # Finally done with dependencies.
 
-if [ -n "$(VBoxManage showvminfo "${vmname}")" ]; then
+if VBoxManage list vms | grep -q "${vmname}"; then
     echo "${vmname} virtual machine already exists. Exiting."
     exit
 fi


### PR DESCRIPTION
Currently on Linux host, when there is no vm named `Mojave`, running `VBoxManage showvminfo Mojave` will return
```
VBoxManage: error: Could not find a registered machine named 'Mojave'
VBoxManage: error: Details: code VBOX_E_OBJECT_NOT_FOUND (0x80bb0001), component VirtualBoxWrap, interface IVirtualBox, callee nsISupports
VBoxManage: error: Context: "FindMachine(Bstr(VMNameOrUuid).raw(), machine.asOutParam())" at line 2834 of file VBoxManageInfo.cpp
```
so `[ -n "$(VBoxManage showvminfo "${vmname}")" ]` would still return true.