### PR TITLE
Optional serialnumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tested on Cygwin, should work on Linux distros.
 
 ## iCloud and iMessage connectivity
 
-iCloud and iMessage and other connected Apple services require a valid device serial number. Set it before the installation by replacing the zeroes in `serialnumber="000000000000"` with a valid serial number, or after the installation with `VBoxManage setextradata "${vmname}" "VBoxInternal/Devices/efi/0/Config/DmiSystemSerial" "${serialnumber}"`. An invalid serial number that matches the correct structure for the device name and board ID might work, too.
+iCloud and iMessage and other connected Apple services require a valid device serial number. Set it before the installation by replacing the empty string in `serialnumber=""` with a valid serial number, or after the installation with `VBoxManage setextradata "${vmname}" "VBoxInternal/Devices/efi/0/Config/DmiSystemSerial" "${serialnumber}"`. An invalid serial number that matches the correct structure for the device name and board ID might work, too.
 
 ## Dependencies
 

--- a/macos_okiomov.sh
+++ b/macos_okiomov.sh
@@ -14,7 +14,7 @@ cpucount=2                  # VM CPU cores, minimum 2
 memorysize=4096             # VM RAM in MB, minimum 2048 
 gpuvram=128                 # VM video RAM in MB, minimum 34
 resolution="1280x800"       # display resolution
-serialnumber="000000000000" # valid serial required for iCloud, iMessage.
+serialnumber="" # valid serial required for iCloud, iMessage.
 # Structure:  PPPYWWUUUCCC - plant, year, week, unique identifier, model
 # Whether the serial is valid depends on the device name and board, below
 devicename="MacBookPro11,3" 
@@ -156,8 +156,10 @@ VBoxManage setextradata "${vmname}" \
  "VBoxInternal/Devices/smc/0/Config/GetKeyFromRealSMC" 1
 VBoxManage setextradata "${vmname}" \
  "VBoxInternal2/EfiGraphicsResolution" "${resolution}"
-VBoxManage setextradata "${vmname}" \
- "VBoxInternal/Devices/efi/0/Config/DmiSystemSerial" "${serialnumber}"
+if [ -n "${serialnumber}" ]; then
+    VBoxManage setextradata "${vmname}" \
+     "VBoxInternal/Devices/efi/0/Config/DmiSystemSerial" "${serialnumber}"
+fi
 
 # sterr back
 exec 2>/dev/tty


### PR DESCRIPTION
Currently if I don't care about iCloud or other Apple services I have to go into `macos_okiomov.sh` and delete `VBoxManage setextradata "${vmname}" "VBoxInternal/Devices/efi/0/Config/DmiSystemSerial" "${serialnumber}"`.

This makes it more convenient to leave out `serialnumber` (which can always be added later by running the command separately).